### PR TITLE
Add structured output mapping for Ollama

### DIFF
--- a/aicode/codex-report-2025-10-07T00:51:32.149887+00:00.md
+++ b/aicode/codex-report-2025-10-07T00:51:32.149887+00:00.md
@@ -1,0 +1,6 @@
+## 2025-10-07T00:51:32.149887+00:00
+
+- Ollama provider: Translate `response_schema` metadata into the provider-specific `format` request field and preserve schema description/title values when forwarding JSON Schema payloads.
+- Model API: Clarify that `ResponseSchema.strict` is ignored by Ollama and extend the `GenerateConfig` documentation to list Ollama alongside other providers that accept JSON schema outputs.
+- Tests: Restructure the Ollama parameter-mapping regression test to follow provider test conventions by using pytest fixtures and direct instance method calls.
+- Tooling: Added a Codex change report for this branch detailing structured-output handling improvements and accompanying test updates.

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -23,7 +23,7 @@ class ResponseSchema(BaseModel):
 
     strict: bool | None = Field(default=None)
     """Whether to enable strict schema adherence when generating the output. If set to true, the model will always follow the exact schema defined in the schema field.
-    OpenAI and Mistral only."""
+    OpenAI and Mistral only. Ignored by Ollama."""
 
 
 class BatchConfig(BaseModel):
@@ -131,7 +131,7 @@ class GenerateConfigArgs(TypedDict, total=False):
     """Include reasoning in chat message history sent to generate."""
 
     response_schema: ResponseSchema | None
-    """Request a response format as JSONSchema (output should still be validated). OpenAI, Google, and Mistral only."""
+    """Request a response format as JSONSchema (output should still be validated). OpenAI, Google, Mistral, and Ollama only."""
 
     extra_body: dict[str, Any] | None
     """Extra body to be sent with requests to OpenAI compatible servers. OpenAI, vLLM, and SGLang only."""

--- a/src/inspect_ai/model/_providers/ollama.py
+++ b/src/inspect_ai/model/_providers/ollama.py
@@ -29,6 +29,18 @@ class OllamaAPI(OpenAICompatibleAPI):
     def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
         params = super().completion_params(config, tools)
 
+        if config.response_schema is not None:
+            schema = config.response_schema.json_schema.model_dump(exclude_none=True)
+            if config.response_schema.description and "description" not in schema:
+                schema = {
+                    **schema,
+                    "description": config.response_schema.description,
+                }
+            if config.response_schema.name and "title" not in schema:
+                schema = {**schema, "title": config.response_schema.name}
+            params.pop("response_format", None)
+            params["format"] = schema
+
         # Ollama uses `"reasoning": { "effort": _ }`
         # instead of `"reasoning_effort": _`
         # https://github.com/ollama/ollama/blob/f2e9c9aff5f59b21a5d9a9668408732b3de01e20/openai/openai.go#L105

--- a/tests/model/providers/test_ollama.py
+++ b/tests/model/providers/test_ollama.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from inspect_ai.model import GenerateConfig, ResponseSchema
+from inspect_ai.model._providers.ollama import OllamaAPI
+from inspect_ai.util import json_schema
+
+
+class Color(BaseModel):
+    red: int
+    green: int
+    blue: int
+
+
+@pytest.fixture()
+def ollama_api() -> OllamaAPI:
+    api = OllamaAPI.__new__(OllamaAPI)
+    api.model_name = "ollama/llama3.1"
+    api.service = "Ollama"
+    return api
+
+
+def test_ollama_structured_output_completion_params(ollama_api: OllamaAPI) -> None:
+    config = GenerateConfig(
+        response_schema=ResponseSchema(
+            name="color",
+            description="RGB color values",
+            json_schema=json_schema(Color),
+            strict=True,
+        )
+    )
+
+    params = ollama_api.completion_params(config=config, tools=False)
+
+    assert "response_format" not in params
+    assert params["format"] == {
+        "type": "object",
+        "properties": {
+            "red": {"type": "integer"},
+            "green": {"type": "integer"},
+            "blue": {"type": "integer"},
+        },
+        "additionalProperties": False,
+        "required": ["red", "green", "blue"],
+        "description": "RGB color values",
+        "title": "color",
+    }


### PR DESCRIPTION
## Summary
- send structured output schemas to Ollama using the provider-specific `format` field and propagate schema metadata
- document that `response_schema` is available for Ollama and clarify strict-mode support
- add a regression test covering the Ollama completion parameter mapping for structured outputs and align it with the provider test conventions while recording the branch changes in `aicode/codex-report-2025-10-07T00:51:32.149887+00:00.md`

## Testing
- PYTHONPATH=src pytest tests/model/providers/test_ollama.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e41df33e6c832db2071d94ca7a1392